### PR TITLE
Actually build binaries with go 1.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.21.x
 
       # Build release
       - name: Build project


### PR DESCRIPTION
Docker built with 1.21, but binary builds were still using 1.17. This release fixes that.